### PR TITLE
Support following/tailing the cursor

### DIFF
--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -88,8 +88,8 @@ def main():
 
     logging.info("going to connect")
 
-    src = pymongo.Connection(args.fromhost)
-    dest = pymongo.Connection(args.host, args.port)
+    src = pymongo.MongoClient(args.fromhost)
+    dest = pymongo.MongoClient(args.host, args.port)
 
     if src == dest:
         if any(not any(exp.match(ns) for exp in args.rename) for ns in args.ns) or not args.ns:

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -82,6 +82,16 @@ def rename_dict(spec):
         for old_ns, new_ns in pairs
     }
 
+def _calculate_start(args):
+    # Find out where to start from
+    utcnow = calendar.timegm(time.gmtime())
+    if args.seconds:
+        start = bson.timestamp.Timestamp(utcnow - args.seconds, 0)
+    else:
+        day_ago = bson.timestamp.Timestamp(utcnow - 24*60*60, 0)
+        start = read_ts(args.resume_file) or day_ago
+    return start
+
 def main():
     args = parse_args()
     setup_logging()
@@ -100,13 +110,7 @@ def main():
 
     logging.info("connected")
 
-    # Find out where to start from
-    utcnow = calendar.timegm(time.gmtime())
-    if args.seconds:
-        start = bson.timestamp.Timestamp(utcnow - args.seconds, 0)
-    else:
-        day_ago = bson.timestamp.Timestamp(utcnow - 24*60*60, 0)
-        start = read_ts(args.resume_file) or day_ago
+    start = _calculate_start(args)
 
     logging.info("starting from %s", start)
     q = {"ts": {"$gte": start}}

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -194,7 +194,7 @@ class Oplog(object):
             time.sleep(1)
 
 
-class TailingOplog(object):
+class TailingOplog(Oplog):
     def query(self, spec):
         cur = self.coll.find(spec, tailable=True, await_data=True)
         # set the oplogReplay flag - not exposed in the public API

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -129,40 +129,40 @@ def main():
             save_ts(doc['ts'], args.resume_file)
 
 def _handle(dest, op, args, num):
-            # Skip "no operation" items
-            if op['op'] == 'n':
-                continue
+    # Skip "no operation" items
+    if op['op'] == 'n':
+        continue
 
-            # Update status
-            ts = op['ts']
-            if not num % 1000:
-                save_ts(ts, args.resume_file)
-                logging.info("%s\t%s\t%s -> %s",
-                             num, ts.as_datetime(),
-                             op.get('op'),
-                             op.get('ns'))
+    # Update status
+    ts = op['ts']
+    if not num % 1000:
+        save_ts(ts, args.resume_file)
+        logging.info("%s\t%s\t%s -> %s",
+                     num, ts.as_datetime(),
+                     op.get('op'),
+                     op.get('ns'))
 
-            # Skip excluded namespaces or namespaces that does not match --ns
-            excluded = any(op['ns'].startswith(ns) for ns in args.exclude)
-            included = any(op['ns'].startswith(ns) for ns in args.ns)
+    # Skip excluded namespaces or namespaces that does not match --ns
+    excluded = any(op['ns'].startswith(ns) for ns in args.exclude)
+    included = any(op['ns'].startswith(ns) for ns in args.ns)
 
-            if excluded or (args.ns and not included):
-                logging.debug("skipping ns %s", op['ns'])
-                continue
+    if excluded or (args.ns and not included):
+        logging.debug("skipping ns %s", op['ns'])
+        continue
 
-            # Rename namespaces
-            for old_ns, new_ns in args.rename.iteritems():
-                if old_ns.match(op['ns']):
-                    ns = old_ns.sub(new_ns, op['ns']).rstrip(".")
-                    logging.debug("renaming %s to %s", op['ns'], ns)
-                    op['ns'] = ns
+    # Rename namespaces
+    for old_ns, new_ns in args.rename.iteritems():
+        if old_ns.match(op['ns']):
+            ns = old_ns.sub(new_ns, op['ns']).rstrip(".")
+            logging.debug("renaming %s to %s", op['ns'], ns)
+            op['ns'] = ns
 
-            # Apply operation
-            try:
-                dbname = op['ns'].split('.')[0] or "admin"
-                dest[dbname].command("applyOps", [op])
-            except pymongo.errors.OperationFailure as e:
-                logging.warning(repr(e))
+    # Apply operation
+    try:
+        dbname = op['ns'].split('.')[0] or "admin"
+        dest[dbname].command("applyOps", [op])
+    except pymongo.errors.OperationFailure as e:
+        logging.warning(repr(e))
 
 
 def get_latest_ts(oplog):

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -177,6 +177,29 @@ def main():
     finally:
         save_ts(ts, args.resume_file)
 
+def tail_oplog(db, collection='oplog.rs', last_ts=None):
+    """
+    Tail the oplog, starting from last_ts. If last_ts is None, use the latest
+    doc in the oplog.
+    """
+    oplog = db[collection]
+
+    if last_ts is None:
+        cur = oplog.find().sort('$natural', pymongo.DESCENDING).limit(-1)
+        latest_doc = next(cur)
+        last_ts = latest_doc['ts']
+
+    while True:
+        spec = {'ts': {'$gt': last_ts}}
+        cursor = oplog.find(spec, tailable=True, await_data=True)
+        # oplogReplay flag - not exposed in the public API
+        cursor.add_option(8)
+        while cursor.alive:
+            for doc in cursor:
+                last_ts = doc['ts']
+                yield doc
+            time.sleep(1)
+
 def setup_logging():
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -52,9 +52,9 @@ def parse_args(*args, **kwargs):
     parser.add_argument("-x", "--exclude", nargs="*", default=[],
                         help="exclude namespaces ('dbname' or 'dbname.coll')")
 
-    parser.add_argument("--rename", nargs="*", default={},
+    parser.add_argument("--rename", nargs="*", default=[],
                         metavar="ns_old=ns_new",
-                        type=rename_dict,
+                        type=rename_item,
                         help="rename namespaces before processing on dest")
 
     parser.add_argument("--resume-file", default="mongooplog.ts",
@@ -66,19 +66,20 @@ def parse_args(*args, **kwargs):
                              feature.
                              """)
 
-    return parser.parse_args(*args, **kwargs)
+    args = parser.parse_args(*args, **kwargs)
+    args.replace = dict(args.replace)
+    return args
 
-def rename_dict(spec):
+def rename_item(spec):
     """
-    Return map of old namespace (regex) to the new namespace (string).
+    Return a pair of old namespace (regex) to the new namespace (string).
 
-    spec should be a list of pairs separated by equal signs ('=').
+    spec should be a pair separated by equal sign ('=').
     """
-    pairs = (item.split('=') for item in spec)
-    return {
-        re.compile(r"^{0}(\.|$)".format(re.escape(old_ns))): new_ns + "."
-        for old_ns, new_ns in pairs
-    }
+    old_ns, new_ns = spec.split('=')
+    regex = re.compile(r"^{0}(\.|$)".format(re.escape(old_ns)))
+
+    return regex, new_ns + "."
 
 def _calculate_start(args):
     """

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -152,7 +152,7 @@ def _handle(dest, op, args, num):
         return
 
     # Rename namespaces
-    for old_ns, new_ns in args.rename.iteritems():
+    for old_ns, new_ns in args.rename.items():
         if old_ns.match(op['ns']):
             ns = old_ns.sub(new_ns, op['ns']).rstrip(".")
             logging.debug("renaming %s to %s", op['ns'], ns)

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -83,14 +83,16 @@ def rename_dict(spec):
     }
 
 def _calculate_start(args):
-    # Find out where to start from
+    """
+    Return the start time as a bson timestamp.
+    """
     utcnow = calendar.timegm(time.gmtime())
+
     if args.seconds:
-        start = bson.timestamp.Timestamp(utcnow - args.seconds, 0)
-    else:
-        day_ago = bson.timestamp.Timestamp(utcnow - 24*60*60, 0)
-        start = read_ts(args.resume_file) or day_ago
-    return start
+        return bson.timestamp.Timestamp(utcnow - args.seconds, 0)
+
+    day_ago = bson.timestamp.Timestamp(utcnow - 24*60*60, 0)
+    return read_ts(args.resume_file) or day_ago
 
 def main():
     args = parse_args()

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -67,7 +67,7 @@ def parse_args(*args, **kwargs):
                              """)
 
     args = parser.parse_args(*args, **kwargs)
-    args.replace = dict(args.replace)
+    args.rename = dict(args.rename)
     return args
 
 def rename_item(spec):

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import argparse
-import calendar
-import datetime
 import time
 import json
 import logging
@@ -86,7 +84,7 @@ def _calculate_start(args):
     """
     Return the start time as a bson timestamp.
     """
-    utcnow = calendar.timegm(time.gmtime())
+    utcnow = time.time()
 
     if args.seconds:
         return bson.timestamp.Timestamp(utcnow - args.seconds, 0)

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -131,7 +131,7 @@ def main():
 def _handle(dest, op, args, num):
     # Skip "no operation" items
     if op['op'] == 'n':
-        continue
+        return
 
     # Update status
     ts = op['ts']
@@ -148,7 +148,7 @@ def _handle(dest, op, args, num):
 
     if excluded or (args.ns and not included):
         logging.debug("skipping ns %s", op['ns'])
-        continue
+        return
 
     # Rename namespaces
     for old_ns, new_ns in args.rename.iteritems():

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -185,12 +185,14 @@ class Oplog(object):
         """
         spec = {'ts': {'$gt': ts}}
         cursor = self.query(spec)
-        while cursor.alive:
+        while True:
             # todo: trap InvalidDocument errors:
             # except bson.errors.InvalidDocument as e:
             #  logging.info(repr(e))
             for doc in cursor:
                 yield doc
+            if not cursor.alive:
+                break
             time.sleep(1)
 
 

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -84,7 +84,7 @@ def _calculate_start(args):
     """
     Return the start time as a bson timestamp.
     """
-    utcnow = time.time()
+    utcnow = int(time.time())
 
     if args.seconds:
         return bson.timestamp.Timestamp(utcnow - args.seconds, 0)

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -20,7 +20,7 @@ import pymongo
 import bson
 import re
 
-def parse_args():
+def parse_args(*args, **kwargs):
     parser = argparse.ArgumentParser(add_help=False)
 
     parser.add_argument("--help",
@@ -66,7 +66,7 @@ def parse_args():
                              feature.
                              """)
 
-    return parser.parse_args()
+    return parser.parse_args(*args, **kwargs)
 
 def rename_dict(spec):
     """

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -177,7 +177,7 @@ class Oplog(object):
         return latest_doc['ts']
 
     def query(self, spec):
-        return self.coll.find(spec, tailable=True, await_data=True)
+        return self.coll.find(spec)
 
     def since(self, ts):
         """


### PR DESCRIPTION
I found that mongooplog-alt wasn't actually following the cursor, even when I supplied -f. I've previously worked on a project where Bernie Hackett provided me with a recipe for tailing the oplogs reliably.

As a result, I've refactored the code to implement that technique. I recommend reviewing this PR on a commit-by-commit basis. I tried to make each commit isolated and stable.
