### PR TITLE
Add support for Python 3

### DIFF
--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -112,7 +112,7 @@ def main():
     try:
         while oplog.alive:
             try:
-                op = oplog.next()
+                op = next(oplog)
             except StopIteration:
                 if not args.follow:
                     logging.info("all done")

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -21,6 +21,7 @@ import logging
 import pymongo
 import bson
 import re
+import sys
 
 def parse_args():
     parser = argparse.ArgumentParser(add_help=False)
@@ -148,7 +149,7 @@ def main():
                 continue
 
             # Rename namespaces
-            for old_ns, new_ns in rename.iteritems():
+            for old_ns, new_ns in _iteritems(rename):
                 if old_ns.match(op['ns']):
                     ns = old_ns.sub(new_ns, op['ns']).rstrip(".")
                     logging.debug("renaming %s to %s", op['ns'], ns)
@@ -166,6 +167,14 @@ def main():
 
     finally:
         save_ts(ts, args.resume_file)
+
+PY3 = sys.version_info > (3,)
+
+def _iteritems(dict):
+    if PY3:
+        return dict.items()
+    else:
+        return dict.iteritems()
 
 def setup_logging():
     logger = logging.getLogger()

--- a/mongooplog_alt.py
+++ b/mongooplog_alt.py
@@ -21,7 +21,6 @@ import logging
 import pymongo
 import bson
 import re
-import sys
 
 def parse_args():
     parser = argparse.ArgumentParser(add_help=False)
@@ -149,7 +148,7 @@ def main():
                 continue
 
             # Rename namespaces
-            for old_ns, new_ns in _iteritems(rename):
+            for old_ns, new_ns in rename.items():
                 if old_ns.match(op['ns']):
                     ns = old_ns.sub(new_ns, op['ns']).rstrip(".")
                     logging.debug("renaming %s to %s", op['ns'], ns)
@@ -167,14 +166,6 @@ def main():
 
     finally:
         save_ts(ts, args.resume_file)
-
-PY3 = sys.version_info > (3,)
-
-def _iteritems(dict):
-    if PY3:
-        return dict.items()
-    else:
-        return dict.iteritems()
 
 def setup_logging():
     logger = logging.getLogger()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ classifiers = """\
 Development Status :: 4 - Beta
 Intended Audience :: Developers
 License :: OSI Approved :: Apache Software License
-Programming Language :: Python
+Programming Language :: Python :: 2.7
+Programming Language :: Python :: 3
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: OS Independent


### PR DESCRIPTION
I use Python 3 almost exclusively in my environment. I found two errors that prevented the use of this package on Python 3. I fixed those errors and updated the Trove classifiers to reflect support for Python 3.
